### PR TITLE
Added 'true' param to getImageUri for absolute image URIs.

### DIFF
--- a/Classes/Processor/PageProcessor.php
+++ b/Classes/Processor/PageProcessor.php
@@ -149,7 +149,7 @@ class PageProcessor extends AbstractProcessor
 
                         $imageObject->setWidth((int)$processedImage->getProperty('width'));
                         $imageObject->setHeight((int)$processedImage->getProperty('height'));
-                        $imageObject->setUrl($this->imageService->getImageUri($processedImage));
+                        $imageObject->setUrl($this->imageService->getImageUri($processedImage, true));
 
                         $entity->setImage($imageObject);
                     }


### PR DESCRIPTION
Google's micro-data test needs absolute URIs for images.